### PR TITLE
`ep_host` may be blank

### DIFF
--- a/src/dynamo_requests.jl
+++ b/src/dynamo_requests.jl
@@ -74,8 +74,7 @@ end
 
 
 function dynamo_execute(env, action, json_data; current_retry=0)
-    host_base = replace(env.ep_host, r"^ec2.", "")
-    host = "dynamodb.$(host_base)"
+    host = env.ep_host == "" ? "dynamodb.$(env.region).amazonaws.com" : replace(env.ep_host, r"^ec2\.", "dynamodb.")
 
     body = JSON.json(json_data)
     amz_headers = signature_version_4(env, "dynamodb", "POST", host, action, body)


### PR DESCRIPTION
`ep_host` is being deprecated when using Amazon's real services. Allow for when `ep_host` is blank, but don't break when using a Dynamo emulator.
